### PR TITLE
Fixing the binding so it works on mobile browsers

### DIFF
--- a/src/components/vue-suggestion.vue
+++ b/src/components/vue-suggestion.vue
@@ -2,7 +2,8 @@
   <div :class="[wrapperClasses, 'vue-suggestion']">
     <div :class="[{ vs__selected: value }, inputWrapperClasses, 'vs__input-group']">
       <input
-        v-model="searchText"
+        v-bind:value="searchText"
+        v-on:input="searchText = $event.target.value"
         type="search"
         :class="[inputClasses, 'vs__input']"
         :placeholder="placeholder"


### PR DESCRIPTION
If you try using vue-suggestion on mobile now (chrome,firefox etc) the v-model binding never works and the drop down never appears. This fixes this issue. 