### PR TITLE
added  type as prop so we can use Number as type for the input.

### DIFF
--- a/README-v0.md
+++ b/README-v0.md
@@ -47,6 +47,7 @@ Your search engine, your CSS, your everything...
   | minLen | Interger | `2` | Minimun number of characters inputted to start searching |
   | disabled | Boolean | `false` | Disable the input |
   | placeholder | String | `''` | Placeholder of the input |
+  | type | String | `search` | Input type |
 
 ### Events
 

--- a/src/components/vue-suggestion.vue
+++ b/src/components/vue-suggestion.vue
@@ -3,7 +3,7 @@
     <div :class="[{ vs__selected: value }, inputWrapperClasses, 'vs__input-group']">
       <input
         v-model="searchText"
-        type="search"
+        :type="type"
         :class="[inputClasses, 'vs__input']"
         :placeholder="placeholder"
         :disabled="disabled"
@@ -129,6 +129,10 @@ export default {
     suggestionItemClasses: {
       type: String,
       default: () => getDefault('suggestionItemClasses'),
+    },
+    type: {
+      type: String,
+      default: () => getDefault('type'),
     },
   },
   data() {

--- a/src/demo/animals.js
+++ b/src/demo/animals.js
@@ -99,4 +99,5 @@ export default [
   { id: 98, name: 'Rat', description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.' },
   { id: 99, name: 'Moose', description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.' },
   { id: 100, name: 'Cra', description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.' },
+  { id: 100, name: '123456', description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.' },
 ];

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,6 +15,7 @@ export const defaultOptions = {
   suggestionGroupHeaderClasses: '',
   suggestionItemWrapperClasses: '',
   suggestionItemClasses: '',
+  type: 'search',
 };
 
 export default {


### PR DESCRIPTION
Hi there, 

I see that there is an opened issue https://github.com/iamstevendao/vue-suggestion/issues/13, basically it requires to change the type to "number" instead of "search" so I make the changes that are necessary to be able to change the default input type "search" value as any type like "number" by assign it a property with the same name. 
I would appreciate that you evaluate this pull request. I followed the style and conventions and  I already modified the Readme file so users can know about the little feature.

I put an example of animal name with a number as name ("123456") so I can test it , I attach the image so you can see how does it look like.

## vue example
```html
  <vue-suggestion
      v-model="item"
      type="number"
      :items="items"
      :setLabel="setLabel"
      :itemTemplate="itemTemplate"
      maxLen="20"
      @changed="inputChange"
    ></vue-suggestion>
```

## image:
This is the result.
![image](https://user-images.githubusercontent.com/21212423/110231395-2e06c580-7edd-11eb-84e7-16eda6bff555.png)

Let me know if this is right.

Thanks