### PR TITLE
Minor fix on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Suggestion list input for Vue.js
       },
       inputChange (text) {
         // your search method
-        this.items = this.items.filter(item => item.name.contains(text));
+        this.items = this.items.filter(item => item.name.indexOf(text) > -1);
         // now `items` will be showed in the suggestion list
       },
     },


### PR DESCRIPTION
On the documentation, we are trying to access a function **contains** on a string, which gives us an error **contains is not a function**.
